### PR TITLE
Problem of the order of TIA1_Hela clip_data PrismNet pu

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ tools/gdata_bin.sh
 
 To train one single protein model from scratch, run
 ```
-exp/EXP_NAME/train.sh pu PrismNet TIA1_Hela clip_data 
+# exp/EXP_NAME/train.sh pu PrismNet TIA1_Hela clip_data 
+exp/prismnet/train.sh TIA1_Hela clip_data PrismNet pu 
 ```
 where you replace `TIA1_Hela` with the name of the data file you want to use, you replace EXP_NAME with a specific name of this experiment. Hyper-parameters could be tuned in `exp/prismnet/train.sh`. For available training options, please take a look at `tools/train.py`.
 


### PR DESCRIPTION
If using
```
exp/EXP_NAME/train.sh pu PrismNet TIA1_Hela clip_data 
```
then there will have an error
```
FileNotFoundError: [Errno 2] Unable to open file (unable to open file: name = 'data/PrismNet/pu.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)
```
I couldn't understand why there is this weird url 'data/PrismNet/pu.h5' so I decide to change position of the command.

It seems the right order should be: exp/prismnet/train.sh TIA1_Hela clip_data PrismNet pu